### PR TITLE
Add palette command, manual map/elf pair support, and client-side symbol sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- Manual map/elf pairs (settings and command) for builds with non-matching outputs.
+- Symbol sorting by name/address/size within sections in the analyzer view.
+
+### Changed
+- Auto-detection and toolchainPath behavior documented in README.
+
 ## [1.1.2] – 2025‑06‑20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This fork removes that dependency, adds broader file handling, and enhances the 
 ✅ **Removed CMake dependency** – Works with any build system (Makefile, CubeIDE, etc.)  
 ✅ **Custom build folder support** – Easily set via UI button or command  
 ✅ **Improved file discovery** – More robust handling of `.map` and `.elf` files  
-✅ **Optimized UI** – Visual memory usage indicators and new interactive controls  
+✅ **Optimized UI** – Visual memory usage indicators and sortable symbol view  
 
 ---
 
@@ -30,6 +30,7 @@ This fork removes that dependency, adds broader file handling, and enhances the 
 - Detailed breakdown of memory sections and symbols
 - Clickable links from symbols to source files
 - Visual panel with color-coded usage (RAM, Flash)
+- Sorting by symbol name/address/size within each section
 - ARM toolchain integration (`arm-none-eabi-objdump`, `nm`)
 - Compatible with any STM32 build system
 
@@ -81,7 +82,55 @@ This fork removes that dependency, adds broader file handling, and enhances the 
 - Open the Command Palette (`Ctrl+Shift+P`) and run:
   - `STM32 Build Analyzer` – opens the main view
   - `STM32 Build Analyzer Refresh Paths` – re-detects build output folder
+  - `STM32 Build Analyzer Add Manual Build Pair` – add a manual map/elf pair via prompts
 - Analyzer view updates automatically when build output files change.
+- Click the **Name**, **Address**, or **Size** headers to sort symbols within a section (click again to toggle ascending/descending).
+
+---
+
+## ⚙️ Configuration
+
+The extension auto-detects `.map` + `.elf` files in common build folders. If your build outputs use different names or the ELF has no extension, configure a manual pair so the analyzer can still select the correct files.
+
+### How auto-detection works
+
+1. If **both** `mapFilePath` and `elfFilePath` are set and point to readable files, the extension uses them directly and skips scanning.
+2. Otherwise, it scans common build folders like `build`, `Release`, `Debug`, `out`, and `output`. If none are found, it falls back to scanning the entire workspace.
+3. If multiple candidates are found, you will be prompted to pick the build output (or a manual pair).
+
+### Toolchain path behavior
+
+When `toolchainPath` is set, the extension uses the `arm-none-eabi-objdump` and `arm-none-eabi-nm` binaries from that directory.  
+If it is **not** set (or the binaries are not found), it falls back to using those tools from your system `PATH`.
+
+### Settings reference
+
+| Setting | Type | Default | Description |
+| --- | --- | --- | --- |
+| `stm32BuildAnalyzerEnhanced.mapFilePath` | string | `""` | Absolute path to the `.map` file (overrides automatic search). |
+| `stm32BuildAnalyzerEnhanced.elfFilePath` | string | `""` | Absolute path to the `.elf` file (overrides automatic search). |
+| `stm32BuildAnalyzerEnhanced.toolchainPath` | string | `""` | Absolute path to the ARM GNU Embedded toolchain binaries. |
+| `stm32BuildAnalyzerEnhanced.manualBuildPairs` | array | `[]` | List of manual map/elf pairs for builds with non-matching names or locations. |
+| `stm32BuildAnalyzerEnhanced.debug` | boolean | `false` | Enable verbose logging for debugging purposes. |
+
+### Manual map/elf pairs
+
+Add one or more entries in **Settings → STM32 Build Analyzer (Enhanced) → Manual Build Pairs**:
+
+```json
+"stm32BuildAnalyzerEnhanced.manualBuildPairs": [
+  {
+    "label": "Release build",
+    "folder": "build/Release",
+    "map": "firmware.map",
+    "elf": "firmware.out"
+  }
+]
+```
+
+Paths can be absolute or relative. `map` and `elf` paths may be relative to the `folder` when provided.
+
+You can also add a manual pair from the Command Palette using **STM32 Build Analyzer Add Manual Build Pair**, which writes a new entry into the settings for you.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,14 @@
       {
         "command": "stm32BuildAnalyzerEnhanced.refresh",
         "title": "STM32 Build Analyzer Refresh Paths"
+      },
+      {
+        "command": "stm32BuildAnalyzerEnhanced.refreshPaths",
+        "title": "STM32 Build Analyzer Change Build Folder"
+      },
+      {
+        "command": "stm32BuildAnalyzerEnhanced.addManualPair",
+        "title": "STM32 Build Analyzer Add Manual Build Pair"
       }
     ],
     "configuration": {
@@ -55,6 +63,37 @@
           "type": "boolean",
           "default": false,
           "description": "Enable verbose logging for debugging purposes."
+        },
+        "stm32BuildAnalyzerEnhanced.manualBuildPairs": {
+          "type": "array",
+          "default": [],
+          "description": "Optional list of manual map/elf pairs to use when file names differ or outputs live outside standard build folders.",
+          "items": {
+            "type": "object",
+            "required": [
+              "folder",
+              "map",
+              "elf"
+            ],
+            "properties": {
+              "label": {
+                "type": "string",
+                "description": "Display label for the manual pair."
+              },
+              "folder": {
+                "type": "string",
+                "description": "Build folder path (absolute or workspace-relative)."
+              },
+              "map": {
+                "type": "string",
+                "description": "Map file path (absolute or relative to the build folder)."
+              },
+              "elf": {
+                "type": "string",
+                "description": "ELF file path (absolute or relative to the build folder)."
+              }
+            }
+          }
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,13 @@ import { BuildAnalyzerProvider } from './BuildAnalyzerProvider';
 
 let provider: BuildAnalyzerProvider;
 
+interface ManualBuildPair {
+  label?: string;
+  folder: string;
+  map: string;
+  elf: string;
+}
+
 export function activate(context: vscode.ExtensionContext) {
   const cfg = vscode.workspace.getConfiguration('stm32BuildAnalyzerEnhanced');
   const debug = cfg.get<boolean>('debug') ?? false;
@@ -14,6 +21,12 @@ export function activate(context: vscode.ExtensionContext) {
   provider = new BuildAnalyzerProvider(context);
 
   context.subscriptions.push(
+    vscode.commands.registerCommand('stm32BuildAnalyzerEnhanced.openTab', async () => {
+      if (debug) {console.log('[STM32 Extension] Command: openTab');}
+      await vscode.commands.executeCommand(
+        'workbench.view.extension.buildAnalyzerEnhancedPanel'
+      );
+    }),
     vscode.commands.registerCommand('stm32BuildAnalyzerEnhanced.refresh', () => {
       if (debug) {console.log('[STM32 Extension] Command: refresh');}
       return provider.refresh();
@@ -23,12 +36,70 @@ export function activate(context: vscode.ExtensionContext) {
       if (debug) {console.log('[STM32 Extension] Command: refreshPaths');}
       return provider.fullRefresh();
     }),
+    vscode.commands.registerCommand('stm32BuildAnalyzerEnhanced.addManualPair', async () => {
+      if (debug) {console.log('[STM32 Extension] Command: addManualPair');}
+      await addManualPair(debug);
+    }),
 
     vscode.window.registerWebviewViewProvider('buildAnalyzerEnhanced', provider)
   );
 
   if (debug) {
     console.log('[STM32 Extension] Commands and WebviewViewProvider registered.');
+  }
+}
+
+async function addManualPair(debug: boolean) {
+  const label = await vscode.window.showInputBox({
+    prompt: 'Label for the build pair (optional)',
+    placeHolder: 'Release build',
+  });
+  if (label === undefined) {return;}
+
+  const folder = await vscode.window.showInputBox({
+    prompt: 'Build folder path (absolute or workspace-relative)',
+    placeHolder: 'build/Release',
+  });
+  if (!folder) {return;}
+
+  const map = await vscode.window.showInputBox({
+    prompt: 'Map file path (absolute or relative to the build folder)',
+    placeHolder: 'firmware.map',
+  });
+  if (!map) {return;}
+
+  const elf = await vscode.window.showInputBox({
+    prompt: 'ELF file path (absolute or relative to the build folder)',
+    placeHolder: 'firmware.out',
+  });
+  if (!elf) {return;}
+
+  const scopePick = await vscode.window.showQuickPick(
+    [
+      { label: 'Workspace', target: vscode.ConfigurationTarget.Workspace },
+      { label: 'User', target: vscode.ConfigurationTarget.Global },
+    ],
+    { placeHolder: 'Where should this manual pair be stored?' }
+  );
+  if (!scopePick) {return;}
+
+  const cfg = vscode.workspace.getConfiguration('stm32BuildAnalyzerEnhanced');
+  const current = cfg.get<ManualBuildPair[]>('manualBuildPairs') ?? [];
+  const next: ManualBuildPair[] = [
+    ...current,
+    {
+      label: label?.trim() || undefined,
+      folder: folder.trim(),
+      map: map.trim(),
+      elf: elf.trim(),
+    },
+  ];
+
+  await cfg.update('manualBuildPairs', next, scopePick.target);
+  vscode.window.showInformationMessage('STM32 Build Analyzer: manual pair added.');
+
+  if (debug) {
+    console.log('[STM32 Extension] Manual pair added:', next[next.length - 1]);
   }
 }
 

--- a/src/services/BuildFolderResolver.ts
+++ b/src/services/BuildFolderResolver.ts
@@ -8,6 +8,24 @@ export interface BuildPaths {
   toolchainPath?: string;
 }
 
+interface ManualBuildPair {
+  folder: string;
+  map: string;
+  elf: string;
+  label?: string;
+}
+
+interface ResolvedBuildPair {
+  folder: string;
+  map: string;
+  elf: string;
+  label: string;
+}
+
+type BuildSelection =
+  | { kind: 'manual'; pair: ResolvedBuildPair }
+  | { kind: 'auto'; folder: string };
+
 export class BuildFolderResolver {
   private readonly debug: boolean;
 
@@ -18,14 +36,18 @@ export class BuildFolderResolver {
   }
 
   public async resolve(): Promise<BuildPaths> {
-    const cfg = vscode.workspace.getConfiguration('stm32BuildAnalyzer');
+    const cfg = vscode.workspace.getConfiguration('stm32BuildAnalyzerEnhanced');
     const customMap = cfg.get<string>('mapFilePath');
     const customElf = cfg.get<string>('elfFilePath');
+    const manualPairs = cfg.get<ManualBuildPair[]>('manualBuildPairs') ?? [];
 
     if (this.debug) {
       console.log('[STM32] Resolving build paths...');
       console.log(`[STM32] Custom map: ${customMap}`);
       console.log(`[STM32] Custom elf: ${customElf}`);
+      if (manualPairs.length > 0) {
+        console.log(`[STM32] Manual pairs configured: ${manualPairs.length}`);
+      }
     }
 
     if (customMap && customElf && await this.exists(customMap) && await this.exists(customElf)) {
@@ -46,34 +68,53 @@ export class BuildFolderResolver {
 
     if (this.debug) {console.log(`[STM32] Scanning workspace folder: ${root}`);}
 
+    const resolvedManualPairs = await this.resolveManualPairs(root, manualPairs);
     const folders = await this.findBuildFolders(root);
-    if (folders.length === 0) {
+    const selections = this.buildSelections(resolvedManualPairs, folders);
+    if (selections.length === 0) {
       throw new Error('No build folders containing both .map and .elf found');
     }
 
-    let target = folders[0];
-    if (folders.length > 1) {
+    let selection = selections[0];
+    if (selections.length > 1) {
       if (this.debug) {
-        console.log(`[STM32] Multiple build folders found:`);
-        folders.forEach(f => console.log(` → ${f}`));
+        console.log(`[STM32] Multiple build targets found:`);
+        selections.forEach(s => {
+          if (s.kind === 'manual') {
+            console.log(` → Manual: ${s.pair.folder}`);
+          } else {
+            console.log(` → Auto: ${s.folder}`);
+          }
+        });
       }
 
       const pick = await vscode.window.showQuickPick(
-        folders.map(f => ({ label: path.basename(f), folder: f })),
-        { placeHolder: 'Select build folder with .map & .elf' }
+        selections.map(s => this.toQuickPick(s)),
+        { placeHolder: 'Select build output or manual map/elf pair' }
       );
       if (!pick) {
         throw new Error('Build folder selection cancelled');
       }
-      target = pick.folder;
+      selection = pick.selection;
     }
 
-    if (this.debug) {console.log(`[STM32] Selected folder: ${target}`);}
+    if (selection.kind === 'manual') {
+      if (this.debug) {
+        console.log(`[STM32] Selected manual pair: ${selection.pair.map} + ${selection.pair.elf}`);
+      }
+      return {
+        map: selection.pair.map,
+        elf: selection.pair.elf,
+        toolchainPath: await this.getToolchainPath(),
+      };
+    }
 
-    const mapFile = await this.findFile(target, '.map');
-    const elfFile = await this.findFile(target, '.elf');
+    if (this.debug) {console.log(`[STM32] Selected folder: ${selection.folder}`);}
+
+    const mapFile = await this.findFile(selection.folder, '.map');
+    const elfFile = await this.findFile(selection.folder, '.elf');
     if (!mapFile || !elfFile) {
-      throw new Error(`Missing .map or .elf in ${target}`);
+      throw new Error(`Missing .map or .elf in ${selection.folder}`);
     }
 
     return {
@@ -184,5 +225,68 @@ export class BuildFolderResolver {
       if (this.debug) {console.warn(`[STM32] Could not use file: ${p}`);}
       return undefined;
     }
+  }
+
+  private async resolveManualPairs(root: string, pairs: ManualBuildPair[]): Promise<ResolvedBuildPair[]> {
+    const resolved: ResolvedBuildPair[] = [];
+
+    for (const pair of pairs) {
+      if (!pair.folder || !pair.map || !pair.elf) {
+        if (this.debug) {console.warn('[STM32] Skipping invalid manual pair entry.');}
+        continue;
+      }
+
+      const folderPath = path.isAbsolute(pair.folder)
+        ? pair.folder
+        : path.join(root, pair.folder);
+      const mapPath = path.isAbsolute(pair.map)
+        ? pair.map
+        : path.join(folderPath, pair.map);
+      const elfPath = path.isAbsolute(pair.elf)
+        ? pair.elf
+        : path.join(folderPath, pair.elf);
+
+      const mapOk = await this.exists(mapPath);
+      const elfOk = await this.exists(elfPath);
+
+      if (!mapOk || !elfOk) {
+        if (this.debug) {
+          console.warn(`[STM32] Manual pair not accessible: ${mapPath} ${elfPath}`);
+        }
+        continue;
+      }
+
+      resolved.push({
+        folder: folderPath,
+        map: mapPath,
+        elf: elfPath,
+        label: pair.label ?? path.basename(folderPath),
+      });
+    }
+
+    return resolved;
+  }
+
+  private buildSelections(manualPairs: ResolvedBuildPair[], folders: string[]): BuildSelection[] {
+    const selections: BuildSelection[] = [];
+    manualPairs.forEach(pair => selections.push({ kind: 'manual', pair }));
+    folders.forEach(folder => selections.push({ kind: 'auto', folder }));
+    return selections;
+  }
+
+  private toQuickPick(selection: BuildSelection): vscode.QuickPickItem & { selection: BuildSelection } {
+    if (selection.kind === 'manual') {
+      return {
+        label: `Manual: ${selection.pair.label}`,
+        detail: `${selection.pair.map} | ${selection.pair.elf}`,
+        selection,
+      };
+    }
+
+    return {
+      label: path.basename(selection.folder),
+      detail: selection.folder,
+      selection,
+    };
   }
 }

--- a/src/ui/WebviewRenderer.ts
+++ b/src/ui/WebviewRenderer.ts
@@ -161,7 +161,24 @@ export class WebviewRenderer {
                 #refreshPathsButton:hover {
                     background-color: var(--vscode-button-secondaryHoverBackground);
                 }
-
+                .sortable-header {
+                    cursor: pointer;
+                    user-select: none;
+                }
+                .sort-button {
+                    margin-left: 6px;
+                    padding: 0 4px;
+                    border: 1px solid var(--vscode-button-secondaryBorder);
+                    background: var(--vscode-button-secondaryBackground);
+                    color: var(--vscode-button-secondaryForeground);
+                    border-radius: 2px;
+                    font-size: 10px;
+                    line-height: 1.2;
+                    vertical-align: middle;
+                }
+                .sort-button[data-active="true"] {
+                    border-color: var(--vscode-focusBorder);
+                }
             </style>
         </head>
         <body>
@@ -178,9 +195,15 @@ export class WebviewRenderer {
                 <thead id="regionsHead">
                     <tr>
                         <td></td>
-                        <td>Name</td>
-                        <td>Address</td>
-                        <td>Size</td>
+                        <td class="sortable-header" data-sort-key="name" title="Sort symbols by name">
+                            Name <button class="sort-button" data-sort-key="name" data-active="false" aria-label="Sort by name">⇅</button>
+                        </td>
+                        <td class="sortable-header" data-sort-key="address" title="Sort symbols by address">
+                            Address <button class="sort-button" data-sort-key="address" data-active="false" aria-label="Sort by address">⇅</button>
+                        </td>
+                        <td class="sortable-header" data-sort-key="size" title="Sort symbols by size">
+                            Size <button class="sort-button" data-sort-key="size" data-active="false" aria-label="Sort by size">⇅</button>
+                        </td>
                         <td>Used</td>
                         <td>Free</td>
                     </tr>
@@ -203,27 +226,65 @@ export class WebviewRenderer {
                 function resetTableRegions() {
                     document.getElementById('regionsBody').innerHTML = '';
                 }
+
+                function cloneRegions(regions) {
+                    return regions.map(region => ({
+                        ...region,
+                        sections: region.sections.map(section => ({
+                            ...section,
+                            symbols: [...section.symbols]
+                        }))
+                    }));
+                }
+
+                function compareSymbols(a, b, key, direction) {
+                    let diff = 0;
+                    if (key === 'name') {
+                        diff = a.name.localeCompare(b.name);
+                    } else if (key === 'address') {
+                        diff = a.startAddress - b.startAddress;
+                    } else if (key === 'size') {
+                        diff = a.size - b.size;
+                    }
+                    return direction === 'asc' ? diff : -diff;
+                }
+
+                function sortSymbolsOnly(regions, sortState) {
+                    const sortedRegions = cloneRegions(regions);
+                    if (!sortState.key) {
+                        return sortedRegions;
+                    }
+                    sortedRegions.forEach(region => {
+                        region.sections.forEach(section => {
+                            section.symbols.sort((a, b) => compareSymbols(a, b, sortState.key, sortState.direction));
+                        });
+                    });
+                    return sortedRegions;
+                }
                     
-                function fillTableRegions(regions) {
+                function fillTableRegions(regions, sortState, expandedState) {
                     const tableBody = document.getElementById('regionsBody');
                     tableBody.innerHTML = '';
 
                     let id = 0;
 
-                    regions.forEach(region => {
+                    const displayRegions = sortSymbolsOnly(regions, sortState);
+
+                    displayRegions.forEach(region => {
                         id++;
-                        const regionId = id;
+                        const regionKey = 'region:' + region.name;
                         const percent = region.used / region.size * 100;
+                        const isRegionExpanded = expandedState.regions.has(regionKey);
 
                         const tableTr = document.createElement('tr');
                         tableTr.className = 'toggleTr level-1';
                         tableTr.setAttribute('data-level', '1');
-                        tableTr.setAttribute('data-id', regionId);
+                        tableTr.setAttribute('data-id', regionKey);
                         
                         const tableTd1 = document.createElement('td');
                         const plus = document.createElement('span');
                         plus.className = 'toggle';
-                        plus.textContent = '+';
+                        plus.textContent = isRegionExpanded ? '−' : '+';
                         tableTd1.appendChild(plus);
                         
                         const bar = document.createElement('div');
@@ -280,18 +341,19 @@ export class WebviewRenderer {
 
                         region.sections.forEach(section => {
                             id++;
-                            const sectionId = id;
+                            const sectionKey = 'section:' + region.name + '::' + section.name;
+                            const isSectionExpanded = expandedState.sections.has(sectionKey);
                             const sectionTr = document.createElement('tr');
                             sectionTr.className = 'toggleTr level-2';
                             sectionTr.setAttribute('data-level', '2');
-                            sectionTr.setAttribute('data-id', sectionId);
-                            sectionTr.setAttribute('data-parent', regionId);
-                            sectionTr.style.display = 'none';
+                            sectionTr.setAttribute('data-id', sectionKey);
+                            sectionTr.setAttribute('data-parent', regionKey);
+                            sectionTr.style.display = isRegionExpanded ? '' : 'none';
 
                             const sectionTd1 = document.createElement('td');
                             const plus = document.createElement('span');
                             plus.className = 'toggle';
-                            plus.textContent = '+';
+                            plus.textContent = isSectionExpanded ? '−' : '+';
                             sectionTd1.appendChild(plus);
 
                             const sectionTd2 = document.createElement('td');
@@ -328,12 +390,13 @@ export class WebviewRenderer {
 
                             section.symbols.forEach(symbol => {
                                 id++;
+                                const symbolKey = 'symbol:' + region.name + '::' + section.name + '::' + symbol.name + '::' + symbol.startAddress;
                                 const pointTr = document.createElement('tr');
                                 pointTr.className = 'toggleTr level-3';
                                 pointTr.setAttribute('data-level', '3');
-                                pointTr.setAttribute('data-id', id);
-                                pointTr.setAttribute('data-parent', sectionId);
-                                pointTr.style.display = 'none';
+                                pointTr.setAttribute('data-id', symbolKey);
+                                pointTr.setAttribute('data-parent', sectionKey);
+                                pointTr.style.display = isRegionExpanded && isSectionExpanded ? '' : 'none';
                                 
                                 const pointTd1 = document.createElement('td');
                                 const pointTd2 = document.createElement('td');
@@ -396,6 +459,10 @@ export class WebviewRenderer {
                     });
                 });
 
+                let lastRegions = [];
+                let sortState = { key: null, direction: 'asc' };
+                const expandedState = { regions: new Set(), sections: new Set() };
+
                 document.getElementById('regionsTable').addEventListener('click', (e) => {
                     const toggleSpan = e.target.closest('.toggle');
                     if (toggleSpan) {
@@ -403,13 +470,13 @@ export class WebviewRenderer {
                         const level = parseInt(tr.getAttribute('data-level'), 10);
                         const parentId = tr.getAttribute('data-id');
 
-                        const childRows = document.querySelectorAll(\`tr[data-parent="\${parentId}"]\`);
+                        const childRows = document.querySelectorAll('tr[data-parent="' + parentId + '"]');
                         childRows.forEach(child => {
                             child.style.display = child.style.display === 'none' ? '' : 'none';
                             const childId = child.getAttribute('data-id');
                             const childLevel = parseInt(child.getAttribute('data-level'), 10);
                             if (child.style.display === 'none' && childLevel === 2) {
-                                const grandChildRows = document.querySelectorAll(\`tr[data-parent="\${childId}"]\`);
+                                const grandChildRows = document.querySelectorAll('tr[data-parent="' + childId + '"]');
                                 grandChildRows.forEach(grandChild => {
                                     if (grandChild.style.display !== 'none') {
                                         grandChild.style.display = 'none';
@@ -418,7 +485,24 @@ export class WebviewRenderer {
                             }
                         });
 
-                        toggleSpan.textContent = toggleSpan.textContent === '+' ? '−' : '+';
+                        const isExpanded = toggleSpan.textContent === '+';
+                        toggleSpan.textContent = isExpanded ? '−' : '+';
+                        if (level === 1) {
+                            if (isExpanded) {
+                                expandedState.regions.add(parentId);
+                            } else {
+                                expandedState.regions.delete(parentId);
+                                const sectionRows = document.querySelectorAll('tr[data-parent="' + parentId + '"][data-level="2"]');
+                                sectionRows.forEach(row => expandedState.sections.delete(row.getAttribute('data-id')));
+                            }
+                        }
+                        if (level === 2) {
+                            if (isExpanded) {
+                                expandedState.sections.add(parentId);
+                            } else {
+                                expandedState.sections.delete(parentId);
+                            }
+                        }
                     }
 
                     const sourceLink = e.target.closest('.source-link');
@@ -432,13 +516,45 @@ export class WebviewRenderer {
                     }
                 });
 
+                function updateSortIndicators() {
+                    document.querySelectorAll('.sort-button').forEach(button => {
+                        const key = button.dataset.sortKey;
+                        const isActive = sortState.key === key;
+                        button.dataset.active = isActive ? 'true' : 'false';
+                        if (!isActive) {
+                            button.textContent = '⇅';
+                            return;
+                        }
+                        button.textContent = sortState.direction === 'asc' ? '▲' : '▼';
+                    });
+                }
+
+                document.getElementById('regionsHead').addEventListener('click', (event) => {
+                    const header = event.target.closest('.sortable-header');
+                    if (!header) {return;}
+                    const key = header.dataset.sortKey;
+                    if (!key) {return;}
+                    if (sortState.key === key) {
+                        sortState.direction = sortState.direction === 'asc' ? 'desc' : 'asc';
+                    } else {
+                        sortState = { key, direction: 'asc' };
+                    }
+                    updateSortIndicators();
+                    if (lastRegions.length > 0) {
+                        resetTableRegions();
+                        fillTableRegions(lastRegions, sortState, expandedState);
+                    }
+                });
+
                 window.addEventListener('message', event => {
                     const message = event.data;
 
                     switch (message.command) {
                         case 'showMapData':
+                            lastRegions = message.data ?? [];
                             resetTableRegions();
-                            fillTableRegions(message.data);
+                            fillTableRegions(lastRegions, sortState, expandedState);
+                            updateSortIndicators();
                             if (message.currentBuildFolderRelativePath) {
                                 const folderDiv = document.getElementById('buildFolderPath');
                                 folderDiv.textContent = message.currentBuildFolderRelativePath;


### PR DESCRIPTION
### Motivation
- Provide a palette command to open the analyzer view container directly via command palette using `openTab`.
- Allow users to register manual `.map`/`.elf` pairs for builds whose outputs don't follow standard names/locations so the analyzer can locate correct files.
- Improve the analyzer UI by enabling symbol sorting and preserving expanded/collapsed state while the webview is open.

### Description
- Registered `stm32BuildAnalyzerEnhanced.openTab` to execute `workbench.view.extension.buildAnalyzerEnhancedPanel` so the view can be opened from the command palette, and exposed `stm32BuildAnalyzerEnhanced.refreshPaths` in `package.json`.
- Added `stm32BuildAnalyzerEnhanced.addManualPair` command and implemented `addManualPair` in `src/extension.ts` which prompts for `label`, `folder`, `map`, `elf`, and scope then updates the `stm32BuildAnalyzerEnhanced.manualBuildPairs` setting via `vscode.workspace.getConfiguration().update()`.
- Added `manualBuildPairs` schema to `package.json` so manual pairs are configurable in settings and visible to users.
- Extended `src/services/BuildFolderResolver.ts` to read, resolve, and validate manual pairs, merge manual and auto-detected targets into a unified quick-pick UI, and return manual pair paths when selected while preserving existing `toolchainPath` fallback behavior.
- Enhanced `src/ui/WebviewRenderer.ts` to add sortable `Name`/`Address`/`Size` headers, client-side sorting logic, deterministic keys for rows, and in-memory `expandedState` so sort and expand/collapse state persist while the view is open.
- Updated `README.md` and `CHANGELOG.md` to document `manualBuildPairs`, the new command, auto-detection/toolchain behavior, and the sortable symbol UI.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968bdea8fc8832986f744c427380d92)