### PR TITLE
Fix: Preserve Scroll Position in Webview Table When Clicking Hyperlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## [1.1.5] – 2026-03-08
+
+### Fixed
+- Preserve scroll position in the webview table when clicking hyperlinks to open source files.
+
 ## [1.1.4] – 2026-01-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ This fork removes that dependency, adds broader file handling, and enhances the 
    ```bash
    vsce package
    ```
-4. This will generate a file like: `stm32-build-analyzer-enhanced-1.1.4.vsix`
+4. This will generate a file like: `stm32-build-analyzer-enhanced-1.1.5.vsix`
 
 5. Install the extension in VS Code: 
    ```bash
-   code --install-extension stm32-build-analyzer-enhanced-1.1.4.vsix
+   code --install-extension stm32-build-analyzer-enhanced-1.1.5.vsix
    ```
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stm32-build-analyzer-enhanced",
-  "version": "1.1.3",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stm32-build-analyzer-enhanced",
-      "version": "1.1.3",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
         "test": "^3.3.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stm32-build-analyzer-enhanced",
   "displayName": "STM32 Build Analyzer (Enhanced)",
   "description": "STM32 Build Analyzer for VSCode - Fork of ATwice291/stm32-build-analyzer with additional features...",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "publisher": "niwciu",
   "license": "MIT",
   "icon": "images/icon2.png",

--- a/resources/build-analyzer.html
+++ b/resources/build-analyzer.html
@@ -16,6 +16,8 @@
       background: var(--vscode-editor-background);
       margin: 0;
       padding: 16px;
+      height: 100vh;
+      overflow: hidden;
     }
 
     .toolbar {
@@ -463,54 +465,56 @@
     <span id="searchMatchCount"></span>
   </div>
 
-  <div class="current-build-folder">
-    <strong>Current Build Folder:</strong>
-    <span id="buildFolderPath"></span>
+  <div id="scroll-container" style="height: 100%; overflow-y: auto;">
+    <div class="current-build-folder">
+      <strong>Current Build Folder:</strong>
+      <span id="buildFolderPath"></span>
+    </div>
+
+    <section id="classicView" class="view-pane">
+      <table id="regionsTable" class="gray">
+        <thead id="regionsHead">
+          <tr>
+            <td></td>
+            <td class="selection-header">
+              Sel <button class="clear-selection" id="clearSelectionButtonClassic" type="button" aria-label="Clear selection">✕</button>
+            </td>
+            <td class="sortable-header" data-sort="name" title="Sort symbols by name">
+              Name <button class="sort-button" data-sort-key="name" data-active="false" aria-label="Sort by name">⇅</button>
+            </td>
+            <td class="sortable-header" data-sort="address" title="Sort symbols by address">
+              Address <button class="sort-button" data-sort-key="address" data-active="false" aria-label="Sort by address">⇅</button>
+            </td>
+            <td class="sortable-header" data-sort="size" title="Sort symbols by size">
+              Size <button class="sort-button" data-sort-key="size" data-active="false" aria-label="Sort by size">⇅</button>
+            </td>
+            <td>Used</td>
+            <td>Free</td>
+          </tr>
+        </thead>
+        <tbody id="regionsBody"></tbody>
+      </table>
+    </section>
+
+    <section id="tableView" class="view-pane is-hidden">
+      <table id="regionsTableModern" class="modern">
+        <thead id="regionsHeadModern">
+          <tr>
+            <th></th>
+            <th class="selection-header">
+              Sel <button class="clear-selection" id="clearSelectionButton" type="button" aria-label="Clear selection">✕</button>
+            </th>
+            <th class="sortable-header" data-sort="name">Name <span id="sort-name" class="sort-indicator">↕</span></th>
+            <th class="sortable-header" data-sort="address">Address <span id="sort-address" class="sort-indicator">↕</span></th>
+            <th class="sortable-header" data-sort="size">Size <span id="sort-size" class="sort-indicator">↕</span></th>
+            <th>Used</th>
+            <th>Free</th>
+          </tr>
+        </thead>
+        <tbody id="regionsBodyModern"></tbody>
+      </table>
+    </section>
   </div>
-
-  <section id="classicView" class="view-pane">
-    <table id="regionsTable" class="gray">
-      <thead id="regionsHead">
-        <tr>
-          <td></td>
-          <td class="selection-header">
-            Sel <button class="clear-selection" id="clearSelectionButtonClassic" type="button" aria-label="Clear selection">✕</button>
-          </td>
-          <td class="sortable-header" data-sort="name" title="Sort symbols by name">
-            Name <button class="sort-button" data-sort-key="name" data-active="false" aria-label="Sort by name">⇅</button>
-          </td>
-          <td class="sortable-header" data-sort="address" title="Sort symbols by address">
-            Address <button class="sort-button" data-sort-key="address" data-active="false" aria-label="Sort by address">⇅</button>
-          </td>
-          <td class="sortable-header" data-sort="size" title="Sort symbols by size">
-            Size <button class="sort-button" data-sort-key="size" data-active="false" aria-label="Sort by size">⇅</button>
-          </td>
-          <td>Used</td>
-          <td>Free</td>
-        </tr>
-      </thead>
-      <tbody id="regionsBody"></tbody>
-    </table>
-  </section>
-
-  <section id="tableView" class="view-pane is-hidden">
-    <table id="regionsTableModern" class="modern">
-      <thead id="regionsHeadModern">
-        <tr>
-          <th></th>
-          <th class="selection-header">
-            Sel <button class="clear-selection" id="clearSelectionButton" type="button" aria-label="Clear selection">✕</button>
-          </th>
-          <th class="sortable-header" data-sort="name">Name <span id="sort-name" class="sort-indicator">↕</span></th>
-          <th class="sortable-header" data-sort="address">Address <span id="sort-address" class="sort-indicator">↕</span></th>
-          <th class="sortable-header" data-sort="size">Size <span id="sort-size" class="sort-indicator">↕</span></th>
-          <th>Used</th>
-          <th>Free</th>
-        </tr>
-      </thead>
-      <tbody id="regionsBodyModern"></tbody>
-    </table>
-  </section>
 
   <script nonce="${nonce}" src="${scriptUri}"></script>
 </body>

--- a/src/ui/WebviewRenderer.ts
+++ b/src/ui/WebviewRenderer.ts
@@ -49,7 +49,7 @@ export class WebviewRenderer {
           vscode.commands.executeCommand('stm32BuildAnalyzerEnhanced.refreshPaths');
           break;
         case 'openFile':
-          this.openFile(msg.filePath, msg.lineNumber);
+          this.openFile(msg.filePath, msg.lineNumber, msg.scrollTop);
           break;
       }
     });
@@ -67,7 +67,7 @@ export class WebviewRenderer {
     });
   }
 
-  private async openFile(file: string, line: number) {
+  private async openFile(file: string, line: number, scrollTop?: number) {
     try {
       if (this.debug) {
         console.log(`[STM32 Webview] Attempting to open file: ${file} @ ${line}`);
@@ -75,10 +75,18 @@ export class WebviewRenderer {
 
       const uri = vscode.Uri.file(file);
       const doc = await vscode.workspace.openTextDocument(uri);
-      const ed = await vscode.window.showTextDocument(doc);
+      const ed = await vscode.window.showTextDocument(doc, { preserveFocus: true });
       const pos = new vscode.Position(line - 1, 0);
       ed.selection = new vscode.Selection(pos, pos);
       ed.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+
+      // Send message to restore scroll position in webview
+      if (scrollTop !== undefined) {
+        this.view.webview.postMessage({
+          command: 'restoreScroll',
+          scrollTop: scrollTop
+        });
+      }
     } catch (err) {
       vscode.window.showErrorMessage(`Cannot open ${file}`);
       if (this.debug) {

--- a/webview/build-analyzer.ts
+++ b/webview/build-analyzer.ts
@@ -812,10 +812,13 @@ function attachTableHandlers(view: ViewMode): void {
 
         if (sourceLink) {
             e.preventDefault();
+            const scrollContainer = document.getElementById('scroll-container') as HTMLElement;
+            const scrollTop = scrollContainer.scrollTop;
             vscode.postMessage({
                 command: 'openFile',
                 filePath: sourceLink.dataset.file,
-                lineNumber: parseInt(sourceLink.dataset.line || '0', 10)
+                lineNumber: parseInt(sourceLink.dataset.line || '0', 10),
+                scrollTop: scrollTop
             });
             return;
         }
@@ -1098,6 +1101,10 @@ window.addEventListener('message', (event: MessageEvent) => {
                     performSearch(searchInput.value.trim(), table);
                 }
             }
+            break;
+        case 'restoreScroll':
+            const scrollContainer = document.getElementById('scroll-container') as HTMLElement;
+            scrollContainer.scrollTo(0, message.scrollTop);
             break;
     }
 });


### PR DESCRIPTION
**Description**
This PR fixes an issue where clicking on hyperlinks in the STM32 Build Analyzer webview would reset the scroll position of the symbols table, disrupting the user experience when examining multiple symbols.

**Changes Made**

- **HTML Structure:** Wrapped the scrollable content (build folder info and tables) in a <div id="scroll-container"> with overflow-y: auto and height: 100%, and set the body to height: 100vh and overflow: hidden to use a custom scroll container instead of the body.

- **Webview Script:** Modified the hyperlink click handler to capture the scroll position from the container and added a message handler to restore it.

- **Extension Renderer:** Updated showTextDocument to use preserveFocus: true to keep the webview focused, and added scroll position saving/restoring as a backup.

- **Changelog:** Added an entry for version 1.1.5 documenting the fix.

**Testing**

- Confirmed that clicking hyperlinks opens the corresponding source files without resetting the table's scroll position.

- Verified that all existing functionality (search, sorting, selection) works as before.

**Impact**

- Improves usability by allowing users to navigate through symbols without losing their place in the table.

- No breaking changes; the fix is backward compatible.